### PR TITLE
Support ext attributes and user tag filter

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.3")
   implementation("com.squareup.okhttp3:okhttp:4.9.1")
 
+  implementation("com.github.h0tk3y.betterParse:better-parse:0.4.2")
+
   implementation("org.slf4j:slf4j-api:2.0.0-alpha1")
   implementation("org.slf4j:slf4j-log4j12:2.0.0-alpha1")
 }

--- a/core/src/main/kotlin/com/samples/verifier/internal/utils/ParseHelper.kt
+++ b/core/src/main/kotlin/com/samples/verifier/internal/utils/ParseHelper.kt
@@ -4,16 +4,20 @@ import com.samples.verifier.Code
 import com.samples.verifier.FileType
 import com.samples.verifier.model.Attribute
 import com.samples.verifier.model.ParseConfiguration
+import com.vladsch.flexmark.ext.attributes.AttributesExtension
 import com.vladsch.flexmark.html.HtmlRenderer
 import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.ast.Node
 import com.vladsch.flexmark.util.data.MutableDataSet
+import com.vladsch.flexmark.util.misc.Extension
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import java.io.File
 import java.util.*
 
 private val parseOptions = MutableDataSet()
+  .set(Parser.EXTENSIONS, Collections.singleton(AttributesExtension.create()) as Collection<Extension>)
+  .toImmutable()
 private val htmlRenderer = HtmlRenderer.builder(parseOptions).build()
 private val htmlParser = Parser.builder(parseOptions).build()
 
@@ -24,6 +28,20 @@ internal fun processHTMLFile(file: File, parseConfiguration: ParseConfiguration)
 internal fun processMarkdownFile(file: File, parseConfiguration: ParseConfiguration): List<Code> {
   return processMarkdownText(file.readText(), parseConfiguration)
 }
+
+/**
+ * Extension attributes
+ *
+ * ```kotlin
+ * //something
+ * ```
+ * {kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
+ *
+ * ===>
+ * <code class="language-kotlin" kotlin-runnable="true" kotlin-min-compiler-version="1.3">
+ * //something
+ * </code>
+ */
 
 internal fun processMarkdownText(text: String, parseConfiguration: ParseConfiguration): List<Code> {
   val node: Node = htmlParser.parse(text)

--- a/core/src/main/kotlin/com/samples/verifier/internal/utils/ParseHelper.kt
+++ b/core/src/main/kotlin/com/samples/verifier/internal/utils/ParseHelper.kt
@@ -65,7 +65,7 @@ internal fun processHTMLText(
   val tagUserFilter = if (isUseFilter) compileFilter(parseConfiguration.tagFilter) else null
 
   val isUseIgnoreFilter = parseConfiguration.ignoreTagFilter.isNotEmpty()
-  val ignoreUFilter = if (isUseFilter) compileFilter(parseConfiguration.ignoreTagFilter) else null
+  val ignoreUFilter = if (isUseIgnoreFilter) compileFilter(parseConfiguration.ignoreTagFilter) else null
 
   queue.addFirst(document.body())
   with(parseConfiguration) {
@@ -73,25 +73,19 @@ internal fun processHTMLText(
       val elem = queue.remove()
       val attrs = elem.attributes().map { Attribute(it.key, it.value) }.toHashSet()
 
-      if (isUseIgnoreFilter) {
-        if (ignoreUFilter?.evaluate(elem) == true) {
-          continue
-        }
-      } else {
-        if (ignoreAttributes != null && attrs.intersect(ignoreAttributes!!).isNotEmpty())
-          continue
-      }
+      if (ignoreUFilter?.evaluate(elem) == true
+        || (ignoreAttributes != null && attrs.intersect(ignoreAttributes!!).isNotEmpty())
+      )
+        continue
 
       queue.addAll(elem.children())
 
-      if (isUseFilter) {
-        if (tagUserFilter?.evaluate(elem) == true) {
-          val code = elem.wholeText().trimIndent()
-          snippets.add(code)
-        }
+      if (tagUserFilter?.evaluate(elem) == true) {
+        val code = elem.wholeText().trimIndent()
+        snippets.add(code)
         continue
       }
-      // else
+
       if ((parseTags != null && (elem.tagName() !in parseTags!!)) ||
         (parseTags == null && elem.tagName() != "code" && fileType == FileType.MD)
       ) {

--- a/core/src/main/kotlin/com/samples/verifier/internal/utils/UserFilter.kt
+++ b/core/src/main/kotlin/com/samples/verifier/internal/utils/UserFilter.kt
@@ -1,0 +1,91 @@
+package com.samples.verifier.internal.utils
+
+import com.github.h0tk3y.betterParse.combinators.*
+import com.github.h0tk3y.betterParse.grammar.Grammar
+import com.github.h0tk3y.betterParse.grammar.parseToEnd
+import com.github.h0tk3y.betterParse.grammar.parser
+import com.github.h0tk3y.betterParse.lexer.literalToken
+import com.github.h0tk3y.betterParse.lexer.regexToken
+import com.github.h0tk3y.betterParse.parser.Parser
+
+import org.jsoup.nodes.Element
+
+sealed class BooleanExpression<T> {
+  abstract fun evaluate(element: T): Boolean
+}
+
+data class Not<T>(val body: BooleanExpression<T>) : BooleanExpression<T>() {
+  override fun evaluate(element: T): Boolean = !body.evaluate(element)
+}
+
+data class And<T>(val left: BooleanExpression<T>, val right: BooleanExpression<T>) : BooleanExpression<T>() {
+  override fun evaluate(element: T): Boolean = left.evaluate(element) && right.evaluate(element)
+}
+
+data class Or<T>(val left: BooleanExpression<T>, val right: BooleanExpression<T>) : BooleanExpression<T>() {
+  override fun evaluate(element: T): Boolean = left.evaluate(element) || right.evaluate(element)
+}
+
+data class Variable(val name: String) {
+  fun evaluate(element: Element): String {
+    if (name == "tag") {
+      return element.tagName()
+    }
+    return "[UNKNOWN]"
+  }
+}
+
+data class Atribute(val name: String) : BooleanExpression<Element>() {
+  override fun evaluate(element: Element): Boolean {
+    return element.attributes().hasKey(name)
+  }
+}
+
+data class CompareAttrOp(val left: Atribute, val right: String) : BooleanExpression<Element>() {
+  override fun evaluate(element: Element): Boolean {
+    val value = element.attributes().get(left.name) ?: return false
+    return value.equals(right)
+  }
+}
+
+data class CompareVarOp(val left: Variable, val right: String) : BooleanExpression<Element>() {
+  override fun evaluate(element: Element): Boolean = left.evaluate(element).equals(right)
+}
+
+object BooleanGrammar : Grammar<BooleanExpression<Element>>() {
+
+  val equ by regexToken("={1,2}")
+  val id by regexToken("[A-Za-z][\\w-]*")
+  val varname by regexToken("#[A-Za-z]\\w*")
+  val quote by regexToken("\"\\w+\"")
+  val lpar by literalToken("(")
+  val rpar by literalToken(")")
+  val not by literalToken("!")
+  val and by regexToken("&{1,2}")
+  val or by regexToken("\\|{1,2}")
+  val ws by regexToken("\\s+", ignore = true)
+
+  val attr: Parser<Atribute> by id map { Atribute(it.text) }
+  val variable: Parser<Variable> by varname map { Variable(it.text.substring(1)) }
+
+  val negation by -not * parser(this::term) map { Not(it) }
+  val bracedExpression by -lpar * parser(this::orChain) * -rpar
+
+
+  val atom: Parser<BooleanExpression<Element>> by
+    (variable * -equ * quote).map { (v, e) -> CompareVarOp(v, e.text.substring(1, e.text.length - 1)) } or
+    (attr * -equ * quote).map { (v, e) -> CompareAttrOp(v, e.text.substring(1, e.text.length - 1)) } or
+    attr
+
+  val term: Parser<BooleanExpression<Element>> by
+    atom or
+    negation or
+    bracedExpression
+
+  val andChain by leftAssociative(term, and) { a, _, b -> And(a, b) }
+  val orChain by leftAssociative(andChain, or) { a, _, b -> Or(a, b) }
+
+  override val rootParser by orChain
+}
+
+internal fun compileFilter(s: String) = BooleanGrammar.parseToEnd(s)

--- a/core/src/main/kotlin/com/samples/verifier/internal/utils/UserFilterHelper.kt
+++ b/core/src/main/kotlin/com/samples/verifier/internal/utils/UserFilterHelper.kt
@@ -79,6 +79,7 @@ private object BooleanGrammar : Grammar<BooleanExpression<Element>>() {
   val not by literalToken("!")
   val and by regexToken("&{1,2}")
   val or by regexToken("\\|{1,2}")
+  val ws by regexToken("\\s+", ignore = true) // is use
   // [-] tokens
 
   val attr: Parser<Atribute> by id map { Atribute(it.text) }

--- a/core/src/main/kotlin/com/samples/verifier/model/ParseConfiguration.kt
+++ b/core/src/main/kotlin/com/samples/verifier/model/ParseConfiguration.kt
@@ -27,6 +27,23 @@ class ParseConfiguration() {
    */
   var parseTags: HashSet<String>? = null
 
+  /**
+   * User filter for tag containing snippet
+   * Special the word #tag means tag name.
+   * Attribute name can implicit transform to true if the attribute exists else false.
+   *
+   * e.g. (#tag="code" & kotlin-runnable="true" & kotlin-min-compiler-version)
+   *
+   * Here kotlin-min-compiler-version implicit transform to true  if the attribute exists.
+   * The filter supports !, & and | operations.
+   */
+  var tagFilter: String = ""
+
+  /**
+   * User filter for ignoring of tag including inners tags.
+   */
+  var ignoreTagFilter: String = ""
+
   constructor(block: ParseConfiguration.() -> Unit) : this() {
     this.block()
   }

--- a/core/src/test/kotlin/com/samples/verifier/ParseMdFileTest.kt
+++ b/core/src/test/kotlin/com/samples/verifier/ParseMdFileTest.kt
@@ -25,4 +25,19 @@ class ParseMdFileTest {
       })
     assertEquals(listOf(1, 2, 3, 4, 5, 6, 7).map { helloWorld }, res)
   }
+  @Test
+  fun `process runnable md test`() {
+    val helloWorld = """
+      fun main() {
+          println("Hello world!")
+      }
+    """.trimIndent()
+    val res = processMarkdownFile(
+      File("src/test/resources/md_runnable_test.md"),
+      ParseConfiguration {
+        tagFilter = "(#tag=\"code\" & kotlin-runnable=\"true\" & kotlin-min-compiler-version)"
+        ignoreTagFilter  = "another-ignore-attribute=\"ignore\" | data-highlight-only"
+      })
+    assertEquals(listOf(1, 2).map { helloWorld }, res)
+  }
 }

--- a/core/src/test/resources/md_runnable_test.md
+++ b/core/src/test/resources/md_runnable_test.md
@@ -1,0 +1,96 @@
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```kotlin
+fun parseInt(str: String): Int? {
+    // ...
+}
+```
+{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
+
+</div>
+
+<div class="sample" markdown="1" theme="idea" data-min-compiler-version="1.3">
+
+```run-kotlin
+fun main() {
+    println("Hello world!")
+}
+```
+{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
+
+</div>
+
+```   kotlin
+// IGNORE  
+fun main() {
+    println("Hello world!")
+}
+```
+{kotlin-runnable="true"}
+
+```   kotlin
+// IGNORE  
+fun main() {
+    println("Hello world!")
+}
+```
+{kotlin-runnable="false"}
+
+
+```kotlin
+fun main() {
+    println("Hello world!")
+}
+```
+texttext
+
+
+```kotlin
+fun main() {
+    println("Hello world!")
+}
+```
+```kk
+ignore
+```
+text
+```kotlin
+fun main() {
+    println("Hello world!")
+}
+```
+texttext
+
+```kk
+ignore
+```
+
+<p class="kotlin">
+    ignore
+</p>
+
+<div class="run-kotlin">
+    fun main() {
+        println("Hello world!")
+    }
+</div>
+
+<div class="sample" markdown="1" theme="idea" another-ignore-attribute="ignore">
+
+```kotlin
+fun parseInt(str: String): Int? {
+    // ...
+}
+```
+
+</div>
+
+<div class="sample" markdown="1" theme="idea" another-ignore-attribute="txx">
+
+```kotlin
+fun main() {
+    println("Hello world!")
+}
+```
+{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
+</div>


### PR DESCRIPTION
  Extension attributes

```
   ```kotlin
   //something
    ```
  {kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
```
represents into html as
```
<code class="language-kotlin" kotlin-runnable="true" kotlin-min-compiler-version="1.3">
//something
</code>
```

In my opinion, it requires a stricter and more flexible  tag filter than simple ```snippet-flag```  and  ```parse-tags```.

I've introduced custom filters in addition. 

 ------
 User filter for tag containing snippet
The special word #tag means a tag name.
The attribute name can implicit transform to true if the attribute exists else false

e.g. ```(#tag="code" & kotlin-runnable="true" & kotlin-min-compiler-version)```

Here kotlin-min-compiler-version implicit transform to true  if the attribute exists  
The filter supports !, & and | operations.
