### PR TITLE
Fix cloning error

### DIFF
--- a/action/src/main/kotlin/com/samples/pusher/client/handler/GitEventHandler.kt
+++ b/action/src/main/kotlin/com/samples/pusher/client/handler/GitEventHandler.kt
@@ -60,9 +60,9 @@ class GitEventHandler(
       return true*/
 
     val collection = verifier.collect(
-      event.pullRequest.base.repo.gitUrl,
+      event.pullRequest.base.repo.htmlUrl,
       event.pullRequest.base.ref,
-      event.pullRequest.head.repo.gitUrl,
+      event.pullRequest.head.repo.htmlUrl,
       event.pullRequest.head.ref,
       options.fileType
     )

--- a/kotlin-samples-verifier/src/main/kotlin/com/samples/verifier/internal/SamplesVerifierInstance.kt
+++ b/kotlin-samples-verifier/src/main/kotlin/com/samples/verifier/internal/SamplesVerifierInstance.kt
@@ -117,7 +117,7 @@ internal class SamplesVerifierInstance(compilerUrl: String, kotlinEnv: KotlinEnv
       val repo = git.repository
       if (filenames == null) processFiles(repo.workTree, type)
       else processFiles(repo.workTree, filenames, type)
-    } ?: emptyList()
+    }
   }
 
   private fun processDiffBranches(
@@ -138,7 +138,7 @@ internal class SamplesVerifierInstance(compilerUrl: String, kotlinEnv: KotlinEnv
         val commonAncestor = mergeBase(git, baseBranch, newName)
         val headCommit = getCommit(git.repository, newName)
         processDiff(git, commonAncestor, headCommit, emptyList(), type)
-    } ?: RepoChanges(null, emptyList())
+    }
   }
 
   private fun <T> cloneRepositoryToDir(
@@ -146,25 +146,24 @@ internal class SamplesVerifierInstance(compilerUrl: String, kotlinEnv: KotlinEnv
     branch: String,
     bare: Boolean = false,
     cb: (Git) -> T
-  ): T? {
+  ): T {
     val dir = File(url.substringAfterLast('/').substringBeforeLast('.'))
     try {
       logger.info("Cloning repository...")
       return cloneRepository(dir, url, branch, bare).use(cb)
     } catch (e: GitException) {
       logger.error("Git: ${e.message}")
+      throw e
     } catch (e: IOException) {
       logger.error("IO: ${e.message}")
-    } catch (e: Exception) {
-      logger.error("${e.message}")
-    } finally {
+      throw e
+    }  finally {
       if (dir.isDirectory) {
         FileUtils.deleteDirectory(dir)
       } else {
         dir.delete()
       }
     }
-    return null
   }
 
   private fun processDiffCommits(
@@ -180,7 +179,7 @@ internal class SamplesVerifierInstance(compilerUrl: String, kotlinEnv: KotlinEnv
         val st = if (startCommitName == null) null else getCommit(git.repository, startCommitName)
         val end = getCommit(git.repository, endCommitName ?: "HEAD")
         processDiff(git, st, end, filenames, type)
-      } ?: RepoChanges(null, emptyList())
+      }
   }
 
   private fun processDiff(


### PR DESCRIPTION
Fix
`134194 [main] ERROR Samples Verifier  - Git: org.eclipse.jgit.api.errors.TransportException: git://github.com/JetBrains/kotlin-web-site.git: Connection timed out (Connection timed out)`

I think a GitHub action does not work with `git://` anymore. 