### PR TITLE
chore: update java target to 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,9 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
+        distribution: 'zulu'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 17
+          distribution: 'zulu'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Creat a secret key file

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
     #      java-version: 15
     - id: clone-compiler-server
       working-directory: ${{ github.action_path }}
-      run: git clone https://github.com/AlexanderPrendota/kotlin-compiler-server --branch master --single-branch kotlin-compiler-server-build
+      run: git clone https://github.com/JetBrains/kotlin-compiler-server --branch master --single-branch kotlin-compiler-server-build
       shell: bash
     - id: build-compiler-server
       working-directory: ${{ github.action_path }}/kotlin-compiler-server-build

--- a/action/build.gradle.kts
+++ b/action/build.gradle.kts
@@ -34,14 +34,14 @@ tasks.test {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 tasks {
     compileKotlin {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -20,14 +20,14 @@ dependencies {
 }
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 tasks {
   compileKotlin {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
   }
   compileTestKotlin {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
   }
 }

--- a/kotlin-samples-verifier/build.gradle.kts
+++ b/kotlin-samples-verifier/build.gradle.kts
@@ -35,10 +35,10 @@ dependencies {
 
 tasks {
   compileKotlin {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
   }
   compileTestKotlin {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
   }
 }
 

--- a/kotlin-samples-verifier/src/main/kotlin/com/samples/verifier/internal/utils/ExecutionHelper.kt
+++ b/kotlin-samples-verifier/src/main/kotlin/com/samples/verifier/internal/utils/ExecutionHelper.kt
@@ -56,7 +56,7 @@ internal class ExecutionHelper(baseUrl: String, private val kotlinEnv: KotlinEnv
     } else throw CallException(response.errorBody()!!.string())
   }
 
-  private fun executeCodeJS(codeSnippet: CodeSnippet): ExecutionResult {
+  private fun executeCodeJS(@Suppress("UNUSED_PARAMETER") codeSnippet: CodeSnippet): ExecutionResult {
     TODO("Not yet implemented")
   }
 }


### PR DESCRIPTION
Kotlin compiler server works on Java 17. (see https://github.com/JetBrains/kotlin-compiler-server/pull/634)