### PR TITLE
Add option for ignore warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ dependencies {
   |-repository (-r) | [String] | Git repository URL with samples to execute| n/a |
   |-tag-filter | [String] | User filter for tag containing snippet  like so: (#tag=\"name\" & attr1=\"val\"). It also supports !, &, / operations | "" |
   |-ignore-tag-filter | [String] | User filter for ignoring of tag including inners tags | "" |
-  
+  | -report-error-only | [Boolean] | Failed only on errors | false |
+
 #### Only for collect:
 | Name (alias) | Format | Description | Default |
 | ------------- |:-------------:| :-----:|:-------------:|

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: 'Create issue and do not push if the snippet has errors equals or greater the severity'
     required: false
     default: 'ERROR'
+  report-error-only:
+    description: 'Report only errors in the output, excluding warnings and other severity levels'
+    required: false
+    default: 'false'
 
   io-event:
     description: 'The default is the event name (automatic mode). It needs to process the github events'

--- a/action/src/main/kotlin/com/samples/pusher/client/Client.kt
+++ b/action/src/main/kotlin/com/samples/pusher/client/Client.kt
@@ -106,6 +106,7 @@ class Client {
           parseTags = options.parseTags?.toHashSet()
           tagFilter = options.tagFilter
           ignoreTagFilter = options.ignoreTagFilter
+          reportErrorOnly = options.reportErrorOnly
         }
     }
 

--- a/action/src/main/kotlin/com/samples/pusher/client/Options.kt
+++ b/action/src/main/kotlin/com/samples/pusher/client/Options.kt
@@ -169,6 +169,9 @@ open class ParseOptions : CompilerOptions() {
 
   @set:Argument("file-type", description = "MD or HTML (type of files to be processed)")
   var fileType: FileType = FileType.MD
+
+  @set:Argument("report-error-only", description = "Failed only on errors")
+  var reportErrorOnly: Boolean = false
 }
 
 open class CompilerOptions {

--- a/kotlin-samples-verifier/src/main/kotlin/com/samples/verifier/internal/SamplesVerifierInstance.kt
+++ b/kotlin-samples-verifier/src/main/kotlin/com/samples/verifier/internal/SamplesVerifierInstance.kt
@@ -6,6 +6,7 @@ import com.samples.verifier.model.CollectionOfRepository
 import com.samples.verifier.model.DiffOfRepository
 import com.samples.verifier.model.ExecutionResult
 import com.samples.verifier.model.ParseConfiguration
+import com.samples.verifier.model.ProjectSeverity
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
 import org.eclipse.jgit.api.Git
@@ -77,7 +78,12 @@ internal class SamplesVerifierInstance(compilerUrl: String, kotlinEnv: KotlinEnv
     val snippets = processRepository(url, branch, type)
     for (codeSnippet in snippets) {
       val result = executionHelper.executeCode(codeSnippet)
-      val errors = result.errors
+      var errors = result.errors
+
+      if (configuration.reportErrorOnly) {
+        errors = errors.filter { it.severity == ProjectSeverity.ERROR }
+      }
+
       if (errors.isNotEmpty()) {
         fail = true
         logger.error("Filename: ${codeSnippet.filename}")

--- a/kotlin-samples-verifier/src/main/kotlin/com/samples/verifier/model/ParseConfiguration.kt
+++ b/kotlin-samples-verifier/src/main/kotlin/com/samples/verifier/model/ParseConfiguration.kt
@@ -44,6 +44,18 @@ class ParseConfiguration() {
    */
   var ignoreTagFilter: String = ""
 
+
+  /**
+   * Indicates whether only errors with severity level `ERROR` should be considered
+   * during the verification process.
+   *
+   * If set to `true`, all other severities such as `INFO` and `WARNING` will be ignored.
+   * This ensures that only critical issues affecting the execution context are reported.
+   *
+   * By default, this is set to `false`, which means errors of all severities are processed.
+   */
+  var reportErrorOnly: Boolean = false
+
   constructor(block: ParseConfiguration.() -> Unit) : this() {
     this.block()
   }

--- a/kotlin-samples-verifier/src/test/kotlin/com/samples/verifier/SamplesVerifierTest.kt
+++ b/kotlin-samples-verifier/src/test/kotlin/com/samples/verifier/SamplesVerifierTest.kt
@@ -3,6 +3,8 @@ package com.samples.verifier
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.collections.map
 
 class SamplesVerifierTest {
   private val samplesVerifier = SamplesVerifierFactory.create().configure {
@@ -157,5 +159,45 @@ class SamplesVerifierTest {
       results.snippets.size,
       2
     )
+  }
+
+  @Test
+  fun `warning test with default`() {
+    assertThrows<SamplesVerifierExceptions> {
+      samplesVerifier.check(
+        "https://github.com/zoobestik/kotlin-samples-verifier.git",
+        "test-warning",
+        FileType.MD,
+      )
+    }
+  }
+
+  @Test
+  fun `warning test with reportErrorOnly=false`() {
+    samplesVerifier.configure {
+      reportErrorOnly = false
+    }
+    assertThrows<SamplesVerifierExceptions> {
+      samplesVerifier.check(
+        "https://github.com/zoobestik/kotlin-samples-verifier.git",
+        "test-warning",
+        FileType.MD,
+      )
+    }
+  }
+
+  @Test
+  fun `warning test with reportErrorOnly=true`() {
+    samplesVerifier.configure {
+      reportErrorOnly = true
+    }
+    assertTrue {
+      samplesVerifier.check(
+        "https://github.com/zoobestik/kotlin-samples-verifier.git",
+        "test-warning",
+        FileType.MD,
+      )
+      true
+    }
   }
 }

--- a/kotlin-samples-verifier/src/test/resources/warning.md
+++ b/kotlin-samples-verifier/src/test/resources/warning.md
@@ -1,0 +1,6 @@
+```run-kotlin
+fun main() {
+    var text = "world"
+    println("Hello $text!")
+}
+```


### PR DESCRIPTION
* Added the `report-error-only` option to the CLI and configuration classes, enabling users to specify that only errors with severity `ERROR` should be considered during sample verification. This is reflected in both the `README.md` and `ParseOptions`/`ParseConfiguration` classes.

**Implementation Changes:**

* Updated the verifier logic in `SamplesVerifierInstance` so that when `reportErrorOnly` is enabled, only errors with severity `ERROR` are processed and reported, ignoring warnings and informational messages.

**Testing Enhancements:**

* Added new unit tests to `SamplesVerifierTest` to verify the behavior of the `reportErrorOnly` flag, ensuring correct handling for default, `false`, and `true` settings. These tests confirm that warnings do not cause failures when the flag is set.
